### PR TITLE
Adding dotenv dummy and a dotenv checker

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+CREDS_KEY=1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+CREDS_IV=abcdef1234567890abcdef1234567890
+MONGO_URI=mongodb+srv://username:password@clusterAddress/databaseName

--- a/api/server/utils/crypto.js
+++ b/api/server/utils/crypto.js
@@ -1,4 +1,8 @@
-require('dotenv').config();
+const dotenvResult = require('dotenv').config();
+if (dotenvResult.error) {
+  console.error('.env error:', dotenvResult.error);
+}
+//console.log('.env loaded variables are:', dotenvResult.parsed);
 
 const crypto = require('crypto');
 const key = Buffer.from(process.env.CREDS_KEY, 'hex');


### PR DESCRIPTION
### Summary - 

To avoid `npm run backend` issue, that points to a missing .env file in the root directory while executing the command - 

![image](https://github.com/ssebowa/ssebowa-UI/assets/41754832/90784982-ff48-49de-9f0c-0c194f821f64)

It will be good to add a .env file to the repo **but considering security issues**, let there be a dummy .env file and the user can populate it with actual values. Especially for -
 - CREDS_KEY
 - CREDS_IV
 - MONGO_URI

also adding a few lines of code as a checker to address any issues that is pointing to the dotenv file.

------------------------------------------------------------------------------------------

### Proof of issue - 

This above error indicates issue in the 5th line of api/server/utils/**crypto.js** - `const key = Buffer.from(process.env.CREDS_KEY, 'hex');`

Adding a few lines to check the root cause - 
![image](https://github.com/ssebowa/ssebowa-UI/assets/41754832/b9d14593-de51-4708-9867-bf42e8e524bc)

The issued narrowed down to this - 
![image](https://github.com/ssebowa/ssebowa-UI/assets/41754832/a38b9e7d-fbfc-4966-8aa1-ed15db88a4e5)

**Hence confirming the missing .env file.**

----------------------------------------------------------------------------------------

### Remediation : 

- Adding a .env file with values fixed the issue here.
- Followed a format for AES-256-CBC the encryption key is 32 bytes (64 characters), and the IV is 16 bytes (32 characters) and a general MongoDB connection url, the dummy data has been put.
- On checking with the above code modifications, it showed that it is pointing to the .env file correctly. 
![image](https://github.com/ssebowa/ssebowa-UI/assets/41754832/d4dc6fc0-65d9-4856-a192-1453691644fa)

